### PR TITLE
Add configurable repl Set to the connection string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,15 +29,16 @@ function prettify (data) {
 
 function applyDefaults (options) {
 	options = options?options:{};
-	if (!options.connectionString) 	{ options.connectionString = '' }
+	if (!options.connectionString)				{ options.connectionString = '' }
+	if (!options.replSet)						{ options.replSet = ''; };
 	if (!options.host) 							{ options.host = 'localhost'; };
 	if (!options.port) 							{ options.port = 27017; }
 	if (!options.authdb) 						{ options.authdb = 'admin'; };
 	if (!options.dbOpts) 						{ options.dbOpts = {w:1}; };
 	if (!options.server) 						{ options.server = {auto_reconnect:true}; };
 	if (!options.format) 						{ options.format = 'raw'; };
-	if (!options.useMasterOplog) 		{ options.useMasterOplog = false; };
-	if (!options.convertObjectIDs) 	{ options.convertObjectIDs = true; };
+	if (!options.useMasterOplog)				{ options.useMasterOplog = false; };
+	if (!options.convertObjectIDs)				{ options.convertObjectIDs = true; };
 	if (!options.onError)		 				{ options.onError = function (error) { console.log('Error - MongoStream:'); console.log(error); }; };
 
 	return options;
@@ -106,8 +107,11 @@ function MongoStream (options) {
 }
 
 function connect(obj) {
-	if (obj.options.connectionString.length > 0)
+	if (obj.options.connectionString.length > 0) {
+		if (obj.options.replSet.length > 0)
+			obj.options.connectionString += '?replicaSet=' + obj.options.replSet;
 		return MongoOplog(obj.options.connectionString, this.options);
+	}
 
 	var connectionString = "mongodb://";
 	var connectionStringOptions = "?";
@@ -119,7 +123,8 @@ function connect(obj) {
 		connectionString += obj.options.password;
 		connectionString += "@";
 		connectionStringOptions += "authSource="+obj.options.authdb;
-		connectionStringOptions += "&replicaSet=rs-ds055316";
+		if (obj.options.replSet.length > 0)
+			connectionStringOptions += "&replicaSet=" + obj.options.replSet;
 	}
 
 	// Kind of Connections


### PR DESCRIPTION
I'm trying to get this to work on an mLab mongo-db via Heroku. I saw the connection string and when using it in conjunction with a replset seems to work but I'm still getting no emitting data. Do you have had any luck with a use-case like this?
